### PR TITLE
chore: add VAT number in receipts

### DIFF
--- a/components/Receipt.js
+++ b/components/Receipt.js
@@ -45,6 +45,11 @@ export class Receipt extends React.Component {
         createdByUser: PropTypes.shape({
           name: PropTypes.string.isRequired,
         }).isRequired,
+        settings: PropTypes.shape({
+          VAT: PropTypes.shape({
+            number: PropTypes.string,
+          }),
+        }),
       }).isRequired,
       host: PropTypes.shape({
         slug: PropTypes.string.isRequired,
@@ -143,6 +148,14 @@ export class Receipt extends React.Component {
       .filter((taxIdNumber) => !isNil(taxIdNumber));
 
     if (taxIdNumbers.length === 0) {
+      const {
+        fromCollective: { settings },
+      } = this.props.invoice;
+
+      if (settings?.VAT?.number) {
+        const vatNumber = settings.VAT.number;
+        return [<P key={vatNumber}>{vatNumber}</P>];
+      }
       return null;
     }
 

--- a/lib/fixtures/donation-receipt.json
+++ b/lib/fixtures/donation-receipt.json
@@ -24,6 +24,7 @@
     "slug": "frank-zappa",
     "name": "Zappa",
     "currency": "USD",
+    "settings": {},
     "location": { "name": "France", "address": "7503 Rockwell Street\nPeabody, MA 01960" },
     "countryISO": "US"
   },

--- a/lib/fixtures/organization-gift-cards-monthly.json
+++ b/lib/fixtures/organization-gift-cards-monthly.json
@@ -30,6 +30,7 @@
     "slug": "amazing-organization",
     "name": "Amazing Organization",
     "currency": "USD",
+    "settings": {},
     "location": {
       "name": null,
       "address": null

--- a/lib/fixtures/organization-gift-cards-yearly.json
+++ b/lib/fixtures/organization-gift-cards-yearly.json
@@ -29,6 +29,7 @@
     "slug": "amazing-organization",
     "name": "Amazing Organization",
     "currency": "USD",
+    "settings": {},
     "location": {
       "name": null,
       "address": null

--- a/lib/fixtures/transactions-with-date-range.json
+++ b/lib/fixtures/transactions-with-date-range.json
@@ -23,6 +23,7 @@
     "slug": "test43wow",
     "name": "Zappa",
     "currency": "USD",
+    "settings": {},
     "location": {
       "name": "France",
       "address": "75 avenue des bacs de fleurs\n83000, Toulon"

--- a/lib/fixtures/transactions-with-tax.json
+++ b/lib/fixtures/transactions-with-tax.json
@@ -29,6 +29,11 @@
     "slug": "betree",
     "name": "Benjamin Piouffle",
     "currency": "EUR",
+    "settings": {
+      "VAT": {
+        "number": "BE0414445663"
+      }
+    },
     "location": {
       "name": "France",
       "address": "98 avenue Gabriel Péri\n92230 Gennevilliers",

--- a/lib/graphql/fragments.js
+++ b/lib/graphql/fragments.js
@@ -33,6 +33,7 @@ export const invoiceFields = gqlV1`
       currency
       type
       isIncognito
+      settings
       location {
         name
         address

--- a/public/static/fixtures/simple-transaction-with-vat.json
+++ b/public/static/fixtures/simple-transaction-with-vat.json
@@ -28,7 +28,11 @@
     "slug": "betree",
     "name": "Benjamin Piouffle",
     "currency": "USD",
-    "settings": {},
+    "settings": {
+      "VAT": {
+        "number": "BE0414445663"
+      }
+    },
     "location": {
       "name": "France",
       "address": "98 avenue Gabriel Péri\n92230 Gennevilliers"


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2931

This PR adds the VAT number to receipts when `orders` don't contain a user's tax number. 

![VAT on invoice](https://user-images.githubusercontent.com/24629960/76722576-8e27b900-671a-11ea-9f64-4483fb392f62.png)
