### PR TITLE
Receipt: Only display extraInfo on last page

### DIFF
--- a/components/Receipt.js
+++ b/components/Receipt.js
@@ -102,10 +102,11 @@ export class Receipt extends React.Component {
     const transactionsPerPage = 22;
 
     // Estimate the space available
-    const countLines = (str) => sumBy(str, (c) => c === '\n');
-    const billFromAddressSize = countLines(get(invoice.host, 'location.address', ''));
-    const billToAddressSize = countLines(get(invoice.fromCollective, 'location.address', ''));
-    const maxNbOnFirstPage = max([minNbOnFirstPage, baseNbOnFirstPage - (billFromAddressSize + billToAddressSize)]);
+    const countLines = (str) => sumBy(str, (c) => c === '\n') + (str.length > 0 ? 1 : 0);
+    const billFromAddressSize = countLines(get(invoice.host, 'location.address') || '');
+    const billToAddressSize = countLines(get(invoice.fromCollective, 'location.address') || '');
+    const totalTextSize = billFromAddressSize + billToAddressSize;
+    const maxNbOnFirstPage = max([minNbOnFirstPage, baseNbOnFirstPage - totalTextSize]);
 
     // If we don't need to put the logo on first page then let's use all the space available
     const nbOnFirstPage = transactions.length > baseNbOnFirstPage ? baseNbOnFirstPage : maxNbOnFirstPage;
@@ -378,11 +379,16 @@ export class Receipt extends React.Component {
                 )}
               </Box>
 
-              <P mt={2} textAlign="left" color="black" padding="4rem 0">
-                {invoice.extraInfo}
-              </P>
-
-              {pageNumber === chunkedTransactions.length - 1 && <CollectiveFooter collective={invoice.host} />}
+              {pageNumber === chunkedTransactions.length - 1 && (
+                <Flex flex="3" flexDirection="column" justifyContent="space-between">
+                  <Box>
+                    <P fontSize="Caption" textAlign="left" whiteSpace="pre-wrap">
+                      {invoice.extraInfo}
+                    </P>
+                  </Box>
+                  <CollectiveFooter collective={invoice.host} />
+                </Flex>
+              )}
             </Flex>
           ))}
         </div>

--- a/lib/fixtures/donation-receipt.json
+++ b/lib/fixtures/donation-receipt.json
@@ -7,6 +7,7 @@
   "year": null,
   "month": null,
   "day": null,
+  "extraInfo": "Qui non moveatur et offensione turpitudinis et comprobatione honestatis? Neminem videbis ita laudatum, ut artifex callidus comparandarum voluptatum diceretur.\nQuid de Pythagora? Res enim concurrent contrariae. Dic in quovis conventu te omnia facere, ne doleas. Sed quid minus probandum quam esse aliquem beatum nec satis beatum?",
   "host": {
     "id": 9805,
     "slug": "opensourceorg",

--- a/lib/fixtures/organization-gift-cards-monthly.json
+++ b/lib/fixtures/organization-gift-cards-monthly.json
@@ -5,6 +5,7 @@
   "currency": "USD",
   "year": 2019,
   "month": 1,
+  "extraInfo": "Qui non moveatur et offensione turpitudinis et comprobatione honestatis? Neminem videbis ita laudatum, ut artifex callidus comparandarum voluptatum diceretur.\nQuid de Pythagora? Res enim concurrent contrariae. Dic in quovis conventu te omnia facere, ne doleas. Sed quid minus probandum quam esse aliquem beatum nec satis beatum?",
   "day": null,
   "host": {
     "id": 11004,


### PR DESCRIPTION
Following up on https://github.com/opencollective/opencollective-pdf/pull/260

- Only display extraInfo on last page (and not on all pages)
- Improve text style and position

![image](https://user-images.githubusercontent.com/1556356/79957040-4d416380-8481-11ea-9674-11ed8c4ad860.png)
