### PR TITLE
Remove CircleCI badge and add GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Collective PDF service
 
-[![Circle CI](https://circleci.com/gh/opencollective/opencollective-invoices/tree/master.svg?style=shield)](https://circleci.com/gh/opencollective/opencollective-invoices/tree/master)
+![Build and Push](https://github.com/wei/pull/workflows/Build%20and%20Push/badge.svg)
 [![Slack Status](https://slack.opencollective.org/badge.svg)](https://slack.opencollective.org)
 [![codecov](https://codecov.io/gh/opencollective/opencollective-invoices/branch/master/graph/badge.svg)](https://codecov.io/gh/opencollective/opencollective-invoices)
 


### PR DESCRIPTION
CircleCI is removed and replaced by GitHub Actions. Therefore the badge should be updated. :smile_cat: 