### PR TITLE
fix(paymentReceipts): prevent expense transactions and self-transactions from payments receipts

### DIFF
--- a/lib/constants/account-type.js
+++ b/lib/constants/account-type.js
@@ -1,0 +1,11 @@
+const AccountType = {
+  BOT: 'BOT',
+  COLLECTIVE: 'COLLECTIVE',
+  EVENT: 'EVENT',
+  FUND: 'FUND',
+  INDIVIDUAL: 'INDIVIDUAL',
+  ORGANIZATION: 'ORGANIZATION',
+  PROJECT: 'PROJECT',
+};
+
+export default AccountType;

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -6,7 +6,6 @@ export async function fetchInvoiceByDateRange(
   accessToken,
   apiKey,
 ) {
-
   const query = gqlV2`
     query InvoiceByDateRange($fromCollectiveSlug: String!, $hostSlug: String!, $dateFrom: ISODateTime!, $dateTo: ISODateTime!, $hasExpense: Boolean) {
       host(slug: $hostSlug) {

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -1,9 +1,14 @@
 import { invoiceFields } from './fragments';
 import { createClient, gqlV1, API_V1_CONTEXT, gqlV2 } from '.';
 
-export async function fetchInvoiceByDateRange({ fromCollectiveSlug, hostSlug, dateFrom, dateTo }, accessToken, apiKey) {
+export async function fetchInvoiceByDateRange(
+  { fromCollectiveSlug, hostSlug, dateFrom, dateTo, hasExpense },
+  accessToken,
+  apiKey,
+) {
+
   const query = gqlV2`
-    query InvoiceByDateRange($fromCollectiveSlug: String!, $hostSlug: String!, $dateFrom: ISODateTime!, $dateTo: ISODateTime!) {
+    query InvoiceByDateRange($fromCollectiveSlug: String!, $hostSlug: String!, $dateFrom: ISODateTime!, $dateTo: ISODateTime!, $hasExpense: Boolean) {
       host(slug: $hostSlug) {
         id
         slug
@@ -32,7 +37,7 @@ export async function fetchInvoiceByDateRange({ fromCollectiveSlug, hostSlug, da
           country
         }
       }
-      transactions(fromAccount: { slug: $fromCollectiveSlug }, host: { slug: $hostSlug }, dateFrom: $dateFrom, dateTo: $dateTo, limit: 1000, includeIncognitoTransactions: true) {
+      transactions(fromAccount: { slug: $fromCollectiveSlug }, host: { slug: $hostSlug }, dateFrom: $dateFrom, dateTo: $dateTo, limit: 1000, includeIncognitoTransactions: true, hasExpense: $hasExpense) {
         totalCount
         nodes {
           id
@@ -94,7 +99,7 @@ export async function fetchInvoiceByDateRange({ fromCollectiveSlug, hostSlug, da
   const client = createClient(accessToken, apiKey);
   const { data } = await client.query({
     query,
-    variables: { fromCollectiveSlug, hostSlug, dateFrom, dateTo },
+    variables: { fromCollectiveSlug, hostSlug, dateFrom, dateTo, hasExpense },
     fetchPolicy: 'no-cache',
   });
 

--- a/pages/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate].js
+++ b/pages/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate].js
@@ -21,17 +21,18 @@ class TransactionReceipt extends React.Component {
         throw new Error('Too many transactions. Please contact support');
       }
 
-      let transactions = response.transactions.nodes
+      let transactions = response.transactions.nodes;
       const fromAccount = response.fromAccount;
 
       if (fromAccount.type === AccountType.ORGANIZATION) {
-        transactions = transactions.filter(transaction => transaction.fromAccount.id !== transaction.toAccount.id)
+        transactions = transactions.filter((transaction) => transaction.fromAccount.id !== transaction.toAccount.id);
       }
-      
+
       if (fromAccount.type === AccountType.INDIVIDUAL) {
-        transactions = transactions.filter(transaction => transaction.type !== 'DEBIT')
+        // Filter out transactions relating to expense but not refund
+        transactions = transactions.filter((transaction) => !(transaction.type === 'DEBIT' && !transaction.isRefund));
       }
-      
+
       return {
         pageFormat: ctx.query.pageFormat,
         receipt: {

--- a/pages/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate].js
+++ b/pages/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate].js
@@ -14,7 +14,7 @@ class TransactionReceipt extends React.Component {
       const { fromCollectiveSlug, toCollectiveSlug: hostSlug, isoStartDate: dateFrom, isoEndDate } = ctx.query;
       const dateTo = isoEndDate.split('.')[0]; // isoEndDate can include file extension
       const accessToken = getAccessTokenFromReq(ctx);
-      const queryParams = { fromCollectiveSlug, hostSlug, dateFrom, dateTo };
+      const queryParams = { fromCollectiveSlug, hostSlug, dateFrom, dateTo, hasExpense: false };
       const response = await fetchInvoiceByDateRange(queryParams, accessToken, ctx.query.app_key);
 
       if (response.transactions.totalCount > response.transactions.nodes.length) {
@@ -26,11 +26,6 @@ class TransactionReceipt extends React.Component {
 
       if (fromAccount.type === AccountType.ORGANIZATION) {
         transactions = transactions.filter((transaction) => transaction.fromAccount.id !== transaction.toAccount.id);
-      }
-
-      if (fromAccount.type === AccountType.INDIVIDUAL) {
-        // Filter out transactions relating to expense but not refund
-        transactions = transactions.filter((transaction) => !(transaction.type === 'DEBIT' && !transaction.isRefund));
       }
 
       return {


### PR DESCRIPTION
Follows up https://github.com/opencollective/opencollective-api/pull/5202 to resolve https://github.com/opencollective/opencollective/issues/3684

- For organizations, transactions to self i.e where `transaction.fromAccount.id === transaction.toAccount.id` should not appear in payment receipts 

- For an individual, transactions with `DEBIT` type, usually an expense transaction should not appear in payment receipts.