### PR TITLE
Addition of `if` conditions to make sure ci runs are not duplicated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   lint:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -52,6 +54,8 @@ jobs:
       - run: npm run lint:quiet
 
   prettier:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The CI now runs fine but when doing pull requests after, https://github.com/opencollective/opencollective-api/pull/5895 but there's a certain case where opening a PR from another branch can duplicate of the CI runs (example: https://github.com/opencollective/opencollective-api/pull/5901). This PR takes care of that. 

Related to https://github.com/opencollective/opencollective/issues/4207