### PR TITLE
Revert "Remove dependabot.yml so that we can migrate to v1"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    timezone: Europe/Berlin
+  reviewers:
+  - Betree
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    timezone: Europe/Berlin
+  reviewers:
+  - Betree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -15,11 +15,22 @@ env:
 
 jobs:
   lint:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout (Push)
+        if: github.event_name == 'push'
         uses: actions/checkout@v2.3.4
+
+      - name: Checkout (Pull Request Target)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2.3.4
+        with:
+          # We are in a pull_request_target event - we need to explicitly checkout the PR's head.
+          # Otherwise we would be running against main branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v2.1.5
@@ -52,11 +63,22 @@ jobs:
       - run: npm run lint:quiet
 
   prettier:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout (Push)
+        if: github.event_name == 'push'
         uses: actions/checkout@v2.3.4
+
+      - name: Checkout (Pull Request Target)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2.3.4
+        with:
+          # We are in a pull_request_target event - we need to explicitly checkout the PR's head.
+          # Otherwise we would be running against main branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v2.1.5
@@ -89,11 +111,22 @@ jobs:
       - run: npm run prettier:check
 
   test:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout (Push)
+        if: github.event_name == 'push'
         uses: actions/checkout@v2.3.4
+
+      - name: Checkout (Pull Request Target)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2.3.4
+        with:
+          # We are in a pull_request_target event - we need to explicitly checkout the PR's head.
+          # Otherwise we would be running against main branch
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v2.1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-  pull_request_target:
+    branches:
+      - main
+  pull_request:
     types:
       - opened
       - synchronize
@@ -15,22 +15,11 @@ env:
 
 jobs:
   lint:
-    if: >-
-      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout (Push)
-        if: github.event_name == 'push'
+      - name: Checkout
         uses: actions/checkout@v2.3.4
-
-      - name: Checkout (Pull Request Target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2.3.4
-        with:
-          # We are in a pull_request_target event - we need to explicitly checkout the PR's head.
-          # Otherwise we would be running against main branch
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v2.1.5
@@ -63,22 +52,11 @@ jobs:
       - run: npm run lint:quiet
 
   prettier:
-    if: >-
-      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout (Push)
-        if: github.event_name == 'push'
+      - name: Checkout
         uses: actions/checkout@v2.3.4
-
-      - name: Checkout (Pull Request Target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2.3.4
-        with:
-          # We are in a pull_request_target event - we need to explicitly checkout the PR's head.
-          # Otherwise we would be running against main branch
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v2.1.5
@@ -111,22 +89,11 @@ jobs:
       - run: npm run prettier:check
 
   test:
-    if: >-
-      github.event_name == 'push' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout (Push)
-        if: github.event_name == 'push'
+      - name: Checkout
         uses: actions/checkout@v2.3.4
-
-      - name: Checkout (Pull Request Target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2.3.4
-        with:
-          # We are in a pull_request_target event - we need to explicitly checkout the PR's head.
-          # Otherwise we would be running against main branch
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node
         uses: actions/setup-node@v2.1.5


### PR DESCRIPTION
Reverts opencollective/opencollective-pdf#669

Reverting this one as we ended up without dependabot on this repo, while I don't think it caused any trouble here? Plus, I don't see it on https://app.dependabot.com/accounts/opencollective and thus I'm not sure whether it's still possible to add it back this way.