### PR TITLE
Receipts: Fix `dateTo` parsing

### DIFF
--- a/pages/receipts/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate]/[filename].js
+++ b/pages/receipts/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate]/[filename].js
@@ -10,8 +10,7 @@ class TransactionReceipt extends React.Component {
   static async getInitialProps(ctx) {
     const isServer = Boolean(ctx.req);
     if (isServer) {
-      const { fromCollectiveSlug, toCollectiveSlug: hostSlug, isoStartDate: dateFrom, isoEndDate } = ctx.query;
-      const dateTo = isoEndDate.split('.')[0]; // isoEndDate can include file extension
+      const { fromCollectiveSlug, toCollectiveSlug: hostSlug, isoStartDate: dateFrom, isoEndDate: dateTo } = ctx.query;
       const accessToken = getAccessTokenFromReq(ctx);
       const queryParams = { fromCollectiveSlug, hostSlug, dateFrom, dateTo };
       const response = await fetchInvoiceByDateRange(queryParams, accessToken, ctx.query.app_key);


### PR DESCRIPTION
Broken in https://github.com/opencollective/opencollective-frontend/pull/6511, parsing is not accepting values like `2021-06-30T23:59:59` anymore, the full `2021-06-30T23:59:59.999Z` is needed.