### PR TITLE
Just display "legalname" instead of "legalname (accountname)" on documents

### DIFF
--- a/components/AccountName.js
+++ b/components/AccountName.js
@@ -4,11 +4,7 @@ import PropTypes from 'prop-types';
  * Displays the name for an account, using its legal name if available.
  */
 const AccountName = ({ account }) => {
-  if (account.legalName && account.name && account.legalName !== account.name) {
-    return `${account.legalName} (${account.name})`;
-  } else {
-    return account.legalName || account.name || account.slug;
-  }
+  return account.legalName || account.name || account.slug;
 };
 
 AccountName.propTypes = {


### PR DESCRIPTION
See #765 and #774

(AFAIK providing a legal name is quite new)
If I enter a legal name, why would I want to see the account name (which is the "display name" and can be some random name) as well on a document e.g. invoice? Isn't that the reason I just enter the legal name? Accounting, tax offices, etc. don't care what your name is on some internet plattform, they just care about the legal name. That's why I think that's when a legal name is provided, is the only thing that should be used, nothing else should be rendered.

BTW: You can achive that right now with a workaround by just going to the settings of a personal or organization account and just remove the account name. That works (see https://github.com/opencollective/opencollective/issues/5002), therefore the code I am changing in this pull request will execute the `else` branch and therefore only the legalname will be shown.
However I don't like this workaround, because I still would like to have my "display name" shown on my profile page below my profile picture.