### PR TITLE
Add deployment details to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ TL;DR: we use [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/)
 ## Tests
 
 You can run the tests using `npm test`.
+
+## Deployment
+
+Merging to `main` branch will auto-deploy the pdf service to Heroku.


### PR DESCRIPTION
Recently I was wondering how the pdf service gets deployed and asked @Betree about it. I think nice to add a small text to our readme for future reference and for anyone who comes across the same question. 😉 