### PR TITLE
Handle refunds in receipt

### DIFF
--- a/components/Receipt.js
+++ b/components/Receipt.js
@@ -23,7 +23,7 @@ import PageFormat from '../lib/constants/page-format';
 import CollectiveFooter from './CollectiveFooter';
 import CustomIntlDate from './CustomIntlDate';
 import AccountName from './AccountName';
-import { H1, H2, P, Span } from '@opencollective/frontend-components/components/Text';
+import { H1, H2, P, Span, Strong } from '@opencollective/frontend-components/components/Text';
 import StyledLink from '@opencollective/frontend-components/components/StyledLink';
 import StyledHr from '@opencollective/frontend-components/components/StyledHr';
 import Container from '@opencollective/frontend-components/components/Container';
@@ -189,9 +189,15 @@ export class Receipt extends React.Component {
 
   /** Get a description for transaction, with a mention to gift card emitter if necessary */
   transactionDescription(transaction) {
+    const isRefunded = !transaction.isRefund && transaction.refundTransaction;
     const targetCollective = getTransactionReceiver(transaction);
     const transactionDescription = (
       <LinkToCollective collective={targetCollective}>
+        {isRefunded && (
+          <Strong fontWeight="700">
+            <FormattedMessage defaultMessage="[REFUNDED]" />{' '}
+          </Strong>
+        )}
         {transaction.description || targetCollective.name || targetCollective.slug}
       </LinkToCollective>
     );
@@ -364,7 +370,9 @@ export class Receipt extends React.Component {
                     </div>
                     {transactions.length === 1 && transactions[0].paymentMethod && (
                       <div>
-                        <label>Payment Method:</label>{' '}
+                        <label>
+                          <FormattedMessage defaultMessage="Payment Method" />:
+                        </label>{' '}
                         {`${transactions[0].paymentMethod.type} ${transactions[0].paymentMethod.name}`}
                       </div>
                     )}

--- a/components/ReceiptV2.js
+++ b/components/ReceiptV2.js
@@ -24,7 +24,7 @@ import CollectiveFooter from './CollectiveFooter';
 import CustomIntlDate from './CustomIntlDate';
 import AccountName from './AccountName';
 import StyledLink from '@opencollective/frontend-components/components/StyledLink';
-import { H1, H2, P, Span } from '@opencollective/frontend-components/components/Text';
+import { H1, H2, P, Span, Strong } from '@opencollective/frontend-components/components/Text';
 import Container from '@opencollective/frontend-components/components/Container';
 import StyledHr from '@opencollective/frontend-components/components/StyledHr';
 
@@ -177,9 +177,15 @@ export class ReceiptV2 extends React.Component {
 
   /** Get a description for transaction, with a mention to gift card emitter if necessary */
   transactionDescription(transaction) {
+    const isRefunded = !transaction.isRefund && transaction.refundTransaction;
     const targetCollective = getTransactionReceiver(transaction);
     const transactionDescription = (
       <LinkToCollective collective={targetCollective}>
+        {isRefunded && (
+          <Strong fontWeight="700">
+            <FormattedMessage defaultMessage="[REFUNDED]" />{' '}
+          </Strong>
+        )}
         {transaction.description || targetCollective.name || targetCollective.slug}
       </LinkToCollective>
     );

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -119,6 +119,9 @@ export async function fetchInvoiceByDateRange(
             type
           }
           isRefund
+          refundTransaction {
+            id
+          }
           order {
             id
             taxes {
@@ -147,7 +150,7 @@ export async function fetchInvoiceByDateRange(
   if (!data.host) {
     throw new Error(`Host ${hostSlug} doesn't exist`);
   } else if (!data.fromAccount) {
-    throw new Error(`Accout ${fromCollectiveSlug} doesn't exist`);
+    throw new Error(`Account ${fromCollectiveSlug} doesn't exist`);
   }
 
   return data;
@@ -230,6 +233,7 @@ export async function fetchTransactionInvoice(transactionUuid, accessToken, apiK
           netAmountInCollectiveCurrency
           taxAmount
           kind
+          isRefund
           invoiceTemplate
           paymentMethod {
             type

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -1,4 +1,4 @@
-import { get, isNil, isUndefined, round, sumBy, uniqBy } from 'lodash';
+import { get, isNil, round, sumBy, uniqBy } from 'lodash';
 
 /** Given a transaction, return the collective that receive the money */
 export const getTransactionReceiver = (transaction) => {
@@ -16,16 +16,6 @@ export const getAmount = (amount) => {
   } else {
     return amount.valueInCents;
   }
-};
-
-/**
- * Check if transaction is a refund, from the proper flag if it comes from V2 or from the
- * description if it comes from V2
- */
-export const isRefundTransaction = (transaction) => {
-  return !isUndefined(transaction.isRefund)
-    ? transaction.isRefund
-    : transaction.refundTransaction && transaction.description.startsWith('Refund of');
 };
 
 /**

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ const nextConfig = {
   images: {
     disableStaticImages: true, // We inline images ourselves for PDF compatibility
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   env: {
     WEBSITE_URL: process.env.WEBSITE_URL,
     API_URL: process.env.API_URL,

--- a/pages/expense/[id]/[filename].js
+++ b/pages/expense/[id]/[filename].js
@@ -15,7 +15,7 @@ class TransactionReceipt extends React.Component {
       if (!accessToken && !ctx.query.app_key) {
         // Frontend sends an OPTIONS request to check CORS, we should just return OK when that happens
         if (ctx.req.method === 'OPTIONS') {
-          return;
+          return {};
         }
 
         throw new Error('Please provide an access token or an APP key');

--- a/pages/receipts/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate]/[filename].js
+++ b/pages/receipts/collectives/[fromCollectiveSlug]/[toCollectiveSlug]/[isoStartDate]/[isoEndDate]/[filename].js
@@ -15,7 +15,7 @@ class TransactionReceipt extends React.Component {
       if (!accessToken && !ctx.query.app_key) {
         // Frontend sends an OPTIONS request to check CORS, we should just return OK when that happens
         if (ctx.req.method === 'OPTIONS') {
-          return;
+          return {};
         }
 
         throw new Error('Please provide an access token or an APP key');

--- a/pages/receipts/transactions/[uuid]/[filename].js
+++ b/pages/receipts/transactions/[uuid]/[filename].js
@@ -16,7 +16,7 @@ class TransactionReceipt extends React.Component {
       if (!accessToken && !ctx.query.app_key) {
         // Frontend sends an OPTIONS request to check CORS, we should just return OK when that happens
         if (ctx.req.method === 'OPTIONS') {
-          return;
+          return {};
         }
 
         throw new Error('Please provide an access token or an APP key');


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5171
Require https://github.com/opencollective/opencollective-api/pull/8866

![image](https://user-images.githubusercontent.com/1556356/235157093-e2e926a8-94e2-4395-b1b9-eab8c6ab493a.png)

After https://github.com/opencollective/opencollective-pdf/pull/912, I want to improve that a bit and make sure all refunds are displayed as "$0" and not summed up.