### PR TITLE
Update "Usage with frontend" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The page will auto-refresh everytime a change is made.
 
 #### Usage with frontend
 
-If you use this service through local frontend, you're ready to go - frontend will pass your authorization token directly to the app.
+If you use this service through local frontend, you will need to add `PDF_SERVICE_URL=http://localhost:3002` line to `.env`. You're ready to go - frontend will pass your authorization token directly to the app.
 
 However this is not practical to develop, you should only use it to debug the
 bridge between the two services.


### PR DESCRIPTION
When I want to download a receipt I get an error without `PDF_SERVICE_URL=http://localhost:3002` line in `.env`.

![image](https://github.com/opencollective/opencollective-pdf/assets/48645737/16e61def-68e4-49bf-869e-3713c7df27a4)
