### PR TITLE
Revert "fix(deps): update dependency express-rate-limit to v8"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dayjs": "1.11.13",
         "dotenv": "17.2.1",
         "express": "5.1.0",
-        "express-rate-limit": "8.0.1",
+        "express-rate-limit": "7.5.1",
         "i18n-iso-countries": "7.14.0",
         "lodash-es": "4.17.21",
         "pdf-fontkit": "1.8.9",
@@ -6747,13 +6747,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
-      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.0.1"
-      },
       "engines": {
         "node": ">= 16"
       },
@@ -8049,15 +8046,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dayjs": "1.11.13",
     "dotenv": "17.2.1",
     "express": "5.1.0",
-    "express-rate-limit": "8.0.1",
+    "express-rate-limit": "7.5.1",
     "i18n-iso-countries": "7.14.0",
     "lodash-es": "4.17.21",
     "pdf-fontkit": "1.8.9",


### PR DESCRIPTION
Reverts opencollective/opencollective-pdf#1123

Many pingdom alerts with rate limit errors after merging this one. The rate limit seems to happen globally, for all IP addresses, as even requests from new IPs get blocked.