### PR TITLE
Validate tax form values query

### DIFF
--- a/server/routes/tax-forms.ts
+++ b/server/routes/tax-forms.ts
@@ -20,12 +20,16 @@ const getValuesFromRequest = (req: express.Request, res: express.Response) => {
     return;
   }
 
-  const rawValues = Buffer.from(base64Values as string, 'base64').toString() || '{}';
+  if (typeof base64Values !== 'string') {
+    res.status(400).send('Missing values');
+    return;
+  }
+
   try {
+    const rawValues = Buffer.from(base64Values, 'base64').toString() || '{}';
     const values = JSON.parse(rawValues);
     return { formType, rawValues, values, isFinal: isFinal?.toString() };
-  } catch (e) {
-    console.error('Error parsing values:', e);
+  } catch {
     res.status(400).send('Invalid values');
     return;
   }
@@ -42,7 +46,6 @@ const MAIN_FONT_BYTES = readFileSyncFromPublicStaticFolder('fonts/NanumGothic-Re
 router.get('/:formType.pdf', async (req: express.Request, res: express.Response) => {
   const parsedRequest = getValuesFromRequest(req, res);
   if (!parsedRequest) {
-    res.status(400).send('Invalid request');
     return;
   }
 

--- a/test/server/index.test.ts
+++ b/test/server/index.test.ts
@@ -13,6 +13,21 @@ describe('Tax forms', () => {
     expect(response.body.message).toBe('Route not found');
   });
 
+  test('returns a 400 when tax form values are missing', async () => {
+    const response = await request(app).get('/tax-forms/W9.pdf?formType=W9');
+    expect(response.status).toBe(400);
+    expect(response.text).toBe('Missing values');
+  });
+
+  test('returns a 400 when tax form values are invalid JSON', async () => {
+    const invalidValues = Buffer.from('{').toString('base64');
+    const response = await request(app).get(
+      `/tax-forms/W9.pdf?formType=W9&values=${encodeURIComponent(invalidValues)}`,
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe('Invalid values');
+  });
+
   describe('PDF Field Visualization', () => {
     for (const [formType, formConfig] of Object.entries(TAX_FORMS)) {
       test(`Show fields for ${formType}`, async () => {


### PR DESCRIPTION
## Summary
- return `400 Missing values` when the tax form endpoint receives no `values` query
- return `400 Invalid values` for malformed base64/JSON payloads without logging a stack trace
- avoid sending a second `400 Invalid request` after the helper already wrote a client-error response
- add regression tests for missing and invalid tax form values

## Validation
- `$env:START_SERVER='false'; npx vitest --run test/server/index.test.ts` (6 passed)
- `npm run type:check`
- `npx prettier --check server/routes/tax-forms.ts test/server/index.test.ts`
- `npx eslint server/routes/tax-forms.ts test/server/index.test.ts`

I also ran the full Vitest suite locally. The touched tax form tests passed, but two existing gift-card visual snapshot tests failed on generated PDF diffs (`gift-cards_multi-page.pdf` and `gift-cards_query_with_cards.pdf`); this appears unrelated to the tax form request validation change.